### PR TITLE
Multiplayer live location sync + docs clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The importer assigns a random six-character `share_code` to every shelter and up
 | POST   | `/sessions`              | Host creates a new shelter session        |
 | POST   | `/sessions/join`         | Join an existing session by shelter code  |
 | POST   | `/sessions/:id/ready`    | Toggle ready state (auth required)        |
+| POST   | `/sessions/:id/heartbeat`| Presence heartbeat (`204` no response body) |
 | POST   | `/sessions/:id/start`    | Host starts the race                      |
 | GET    | `/sessions/:id`          | Fetch lobby snapshot (auth required)      |
 | POST   | `/sessions/:id/finish`   | Mark race finished                        |
@@ -144,6 +145,27 @@ The importer assigns a random six-character `share_code` to every shelter and up
 | GET    | `/question-attributes`   | List question attribute metadata (kind/options) |
 
 Subscribe to `ws://…/sessions/:id/stream?token=…` using the returned JWT token to receive lobby events (`player_joined`, `ready_updated`, etc.).
+
+### Multiplayer live locations (V1)
+
+- Live player markers are shown only after the race starts (`state = racing`).
+- Each client requests a fresh geolocation fix and sends `location_update` every 5 seconds over the existing session WebSocket.
+- Server rounds incoming coordinates to a 50m grid before broadcasting to all players in the same session.
+- Clients render remote players (not self) as labeled map markers and mark them stale after 1 minute without update.
+- If a player has no valid location update, no marker is shown for that player.
+- Small movement under the 50m grid can appear unchanged on the map until the player crosses into the next rounded cell.
+
+WebSocket events used in V1:
+
+- Client to server: `location_update` with `{ lat, lng }`
+- Server to clients:
+  - `player_location_updated`
+  - `player_locations_snapshot` (sent on stream connect)
+  - `player_location_removed` (on leave/disconnect)
+
+Current limitation:
+
+- Location state is in-memory in the API process (no DB persistence). On API restart, live markers rebuild from new client updates.
 
 ## Deployment
 

--- a/api/README.md
+++ b/api/README.md
@@ -68,12 +68,34 @@ The GeoJSON is intentionally kept in a separate data repo (not deployed with the
 | POST   | `/sessions`             | Host creates a new shelter session        |
 | POST   | `/sessions/join`        | Join an existing session by shelter code  |
 | POST   | `/sessions/:id/ready`   | Toggle ready state (auth required)        |
+| POST   | `/sessions/:id/heartbeat`| Presence heartbeat (`204` no response body) |
 | POST   | `/sessions/:id/start`   | Host starts the race                      |
 | GET    | `/sessions/:id`         | Fetch lobby snapshot (auth required)      |
 | POST   | `/sessions/:id/finish`  | Mark race finished                        |
 | POST   | `/tasks/expire-sessions`| Cron endpoint to close expired sessions   |
 
 Subscribe to `ws://.../sessions/:id/stream?token=...` using the returned JWT token to receive lobby events (`player_joined`, `ready_updated`, etc.).
+
+### Live location stream (V1)
+
+The same WebSocket session stream is used for multiplayer player locations.
+
+Behavior:
+
+- Location sharing is active only when the session is in `racing` state.
+- Clients send `location_update` every 5 seconds with `{ lat, lng }`.
+- Server rounds coordinates to a 50m grid before broadcast.
+- Because of 50m rounding, sub-50m movement may not produce a visible marker change.
+- Server emits:
+  - `player_location_updated` (single player update)
+  - `player_locations_snapshot` (latest known locations on connect)
+  - `player_location_removed` (player leaves/disconnects)
+
+Notes:
+
+- Location state is held in memory in `SessionHub` (not persisted in Postgres).
+- Clients treat location entries as stale after 1 minute without update.
+- `POST /sessions/:id/heartbeat` intentionally returns `204 No Content`; this updates `players.last_seen` only.
 
 ## Deployment (Render)
 

--- a/api/src/realtime/sessionHub.ts
+++ b/api/src/realtime/sessionHub.ts
@@ -6,8 +6,16 @@ export interface SessionEvent {
   payload: Record<string, unknown>;
 }
 
+export interface SessionPlayerLocation {
+  user_id: string;
+  lat: number;
+  lng: number;
+  updated_at: number;
+}
+
 export class SessionHub {
   private rooms = new Map<string, Set<WebSocket>>();
+  private playerLocations = new Map<string, Map<string, SessionPlayerLocation>>();
 
   subscribe(sessionId: string, socket: WebSocket) {
     const sockets = this.rooms.get(sessionId) ?? new Set<WebSocket>();
@@ -59,6 +67,32 @@ export class SessionHub {
       }
     }
     this.rooms.delete(sessionId);
+    this.playerLocations.delete(sessionId);
     logger.info({ sessionId }, "Closed session connections");
+  }
+
+  upsertPlayerLocation(sessionId: string, location: SessionPlayerLocation) {
+    const roomLocations = this.playerLocations.get(sessionId) ?? new Map<string, SessionPlayerLocation>();
+    roomLocations.set(location.user_id, location);
+    this.playerLocations.set(sessionId, roomLocations);
+  }
+
+  removePlayerLocation(sessionId: string, userId: string) {
+    const roomLocations = this.playerLocations.get(sessionId);
+    if (!roomLocations) return;
+    roomLocations.delete(userId);
+    if (!roomLocations.size) {
+      this.playerLocations.delete(sessionId);
+    }
+  }
+
+  getPlayerLocations(sessionId: string): SessionPlayerLocation[] {
+    const roomLocations = this.playerLocations.get(sessionId);
+    if (!roomLocations) return [];
+    return Array.from(roomLocations.values());
+  }
+
+  clearPlayerLocations(sessionId: string) {
+    this.playerLocations.delete(sessionId);
   }
 }

--- a/api/src/routes/sessions.ts
+++ b/api/src/routes/sessions.ts
@@ -6,6 +6,7 @@ import {
   finishSession,
   getSessionWithPlayers,
   heartbeatPlayer,
+  isSessionRacing,
   joinSession,
   leaveSession,
   startSession,
@@ -50,6 +51,14 @@ const streamQuerySchema = z.object({
   token: z.string().optional(),
 });
 
+const locationUpdateSchema = z.object({
+  type: z.literal("location_update"),
+  payload: z.object({
+    lat: z.number(),
+    lng: z.number(),
+  }),
+});
+
 const paramsSchema = z.object({
   id: z.string().uuid(),
 });
@@ -61,6 +70,21 @@ function ensureSessionAccess(tokenSessionId: string, requestedId: string) {
 }
 
 const TOKEN_TTL = "3h";
+const LOCATION_ROUNDING_METERS = 50;
+
+const roundToNearestGrid = (lat: number, lng: number, meters = LOCATION_ROUNDING_METERS) => {
+  const metersPerLatDegree = 111_320;
+  const safeLatCos = Math.max(0.000001, Math.cos((lat * Math.PI) / 180));
+  const metersPerLngDegree = metersPerLatDegree * safeLatCos;
+
+  const latRounded = Math.round((lat * metersPerLatDegree) / meters) * (meters / metersPerLatDegree);
+  const lngRounded = Math.round((lng * metersPerLngDegree) / meters) * (meters / metersPerLngDegree);
+
+  return {
+    lat: Number(latRounded.toFixed(6)),
+    lng: Number(lngRounded.toFixed(6)),
+  };
+};
 
 const sessionRoutes: FastifyPluginAsync<{ sessionHub: SessionHub }> = async (fastify, { sessionHub }) => {
   fastify.post("/sessions", async (request, reply) => {
@@ -148,6 +172,7 @@ const sessionRoutes: FastifyPluginAsync<{ sessionHub: SessionHub }> = async (fas
       }
 
       const session = await startSession(params.id, request.user.userId);
+      sessionHub.clearPlayerLocations(params.id);
 
       sessionHub.broadcast(params.id, {
         type: "race_started",
@@ -215,6 +240,11 @@ const sessionRoutes: FastifyPluginAsync<{ sessionHub: SessionHub }> = async (fas
           player_id: result.departedPlayer.id,
         },
       });
+      sessionHub.removePlayerLocation(params.id, request.user.userId);
+      sessionHub.broadcast(params.id, {
+        type: "player_location_removed",
+        payload: { user_id: request.user.userId },
+      });
 
       if (result.promotedHostId) {
         sessionHub.broadcast(params.id, {
@@ -272,6 +302,73 @@ const sessionRoutes: FastifyPluginAsync<{ sessionHub: SessionHub }> = async (fas
             playerId: payload.playerId,
           }),
         );
+
+        const knownLocations = sessionHub.getPlayerLocations(params.id);
+        if (knownLocations.length) {
+          socket.send(
+            JSON.stringify({
+              type: "player_locations_snapshot",
+              sessionId: params.id,
+              timestamp: new Date().toISOString(),
+              payload: { locations: knownLocations },
+            }),
+          );
+        }
+
+        socket.on("message", async (rawMessage) => {
+          const rawText =
+            typeof rawMessage === "string"
+              ? rawMessage
+              : Buffer.isBuffer(rawMessage)
+                ? rawMessage.toString("utf8")
+                : Array.isArray(rawMessage)
+                  ? Buffer.concat(rawMessage).toString("utf8")
+                  : String(rawMessage);
+
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(rawText);
+          } catch {
+            return;
+          }
+
+          const parsedUpdate = locationUpdateSchema.safeParse(parsed);
+          if (!parsedUpdate.success) {
+            return;
+          }
+
+          const { lat, lng } = parsedUpdate.data.payload;
+          if (
+            !Number.isFinite(lat) ||
+            !Number.isFinite(lng) ||
+            Math.abs(lat) > 90 ||
+            Math.abs(lng) > 180
+          ) {
+            return;
+          }
+
+          try {
+            const racing = await isSessionRacing(params.id);
+            if (!racing) {
+              return;
+            }
+
+            const rounded = roundToNearestGrid(lat, lng);
+            const locationPayload = {
+              user_id: payload.userId,
+              lat: rounded.lat,
+              lng: rounded.lng,
+              updated_at: Date.now(),
+            };
+            sessionHub.upsertPlayerLocation(params.id, locationPayload);
+            sessionHub.broadcast(params.id, {
+              type: "player_location_updated",
+              payload: locationPayload,
+            });
+          } catch (error) {
+            request.log.warn({ err: error }, "Failed to process location update");
+          }
+        });
       } catch (error) {
         socket.close(4403, "Invalid token");
       }

--- a/api/src/services/sessionService.ts
+++ b/api/src/services/sessionService.ts
@@ -527,6 +527,14 @@ export async function getSessionWithPlayers(sessionId: string): Promise<SessionW
   return { session, players: playersResult.rows };
 }
 
+export async function isSessionRacing(sessionId: string): Promise<boolean> {
+  const result = await pool.query<Pick<SessionRecord, "state">>(
+    "select state from public.sessions where id = $1 limit 1",
+    [sessionId],
+  );
+  return result.rows[0]?.state === "racing";
+}
+
 export async function expireStaleSessions(): Promise<string[]> {
   const result = await pool.query<{ id: string }>(
     `update public.sessions

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { IntroScreen } from "./components/IntroScreen";
 import { OnboardingScreen } from "./components/OnboardingScreen";
 import { SoloModeScreen } from "./components/SoloModeScreen";
@@ -71,6 +71,9 @@ const GAME_SNAPSHOT_KEY = "shelterhunt.gameSnapshot.v1";
 const GAMEPLAY_SNAPSHOT_KEY = "shelterhunt.gameplaySnapshot.v1";
 const GAME_SNAPSHOT_VERSION = 1;
 const RESUME_GRACE_MS = 10 * 60 * 1000;
+const MULTIPLAYER_LOCATION_UPDATE_MS = 5_000;
+const MULTIPLAYER_LOCATION_STALE_MS = 60_000;
+const MULTIPLAYER_LOCATION_ROUNDING_METERS = 50;
 
 type SessionRole = "host" | "player";
 
@@ -81,6 +84,13 @@ interface MultiplayerSessionContext {
   userId: string;
   role: SessionRole;
   shelterCode: string;
+}
+
+interface MultiplayerPlayerLocation {
+  userId: string;
+  lat: number;
+  lng: number;
+  updatedAt: number;
 }
 
 interface GameSnapshot {
@@ -122,6 +132,27 @@ const mapSessionPlayersToUI = (
       (record.user_id === hostId ? "Host" : `Player ${index + 1}`),
     ready: record.ready,
   }));
+};
+
+const isDefaultStartLocation = (location: { lat: number; lng: number }) => {
+  return (
+    Math.abs(location.lat - defaultCityContext.mapConfig.startLocation.lat) < 1e-6 &&
+    Math.abs(location.lng - defaultCityContext.mapConfig.startLocation.lng) < 1e-6
+  );
+};
+
+const roundLocationToGrid = (location: { lat: number; lng: number }, meters = MULTIPLAYER_LOCATION_ROUNDING_METERS) => {
+  const metersPerLatDegree = 111_320;
+  const safeLatCos = Math.max(0.000001, Math.cos((location.lat * Math.PI) / 180));
+  const metersPerLngDegree = metersPerLatDegree * safeLatCos;
+
+  const lat = Math.round((location.lat * metersPerLatDegree) / meters) * (meters / metersPerLatDegree);
+  const lng = Math.round((location.lng * metersPerLngDegree) / meters) * (meters / metersPerLngDegree);
+
+  return {
+    lat: Number(lat.toFixed(6)),
+    lng: Number(lng.toFixed(6)),
+  };
 };
 
 const buildLocalDesignatedShelters = async (
@@ -226,6 +257,12 @@ export default function App() {
   const [sessionContext, setSessionContext] = useState<MultiplayerSessionContext | null>(null);
   const sessionSocketRef = useRef<WebSocket | null>(null);
   const [socketReconnectKey, setSocketReconnectKey] = useState(0);
+  const latestPlayerLocationRef = useRef(playerLocation);
+  const locationBroadcastInFlightRef = useRef(false);
+  const [multiplayerPlayerLocations, setMultiplayerPlayerLocations] = useState<
+    Record<string, MultiplayerPlayerLocation>
+  >({});
+  const [locationClockTick, setLocationClockTick] = useState(0);
   const [sessionHostId, setSessionHostId] = useState<string | null>(null);
   const [currentShelter, setCurrentShelter] = useState<Shelter | null>(null);
   const [joinCodeScreenOpen, setJoinCodeScreenOpen] = useState(false);
@@ -240,6 +277,42 @@ export default function App() {
     : profileName || defaultSoloName;
   const currentSessionUserId = sessionContext?.userId ?? currentUserId;
   const restoredFromSnapshotRef = useRef(false);
+
+  useEffect(() => {
+    latestPlayerLocationRef.current = playerLocation;
+  }, [playerLocation.lat, playerLocation.lng]);
+
+  useEffect(() => {
+    if (!sessionContext || gameState !== "playing") {
+      return;
+    }
+    const interval = setInterval(() => {
+      setLocationClockTick((tick) => tick + 1);
+    }, 15_000);
+    return () => clearInterval(interval);
+  }, [gameState, sessionContext]);
+
+  const otherPlayerLocations = useMemo(() => {
+    if (!sessionContext || gameState !== "playing") {
+      return [];
+    }
+    const now = Date.now();
+    void locationClockTick;
+    return Object.values(multiplayerPlayerLocations)
+      .filter((location) => location.userId !== currentSessionUserId)
+      .map((location) => {
+        const playerName =
+          players.find((player) => player.id === location.userId)?.name ??
+          t("waiting.player", { fallback: "Player" });
+        return {
+          userId: location.userId,
+          name: playerName,
+          lat: location.lat,
+          lng: location.lng,
+          isStale: now - location.updatedAt >= MULTIPLAYER_LOCATION_STALE_MS,
+        };
+      });
+  }, [currentSessionUserId, gameState, multiplayerPlayerLocations, players, sessionContext, t, locationClockTick]);
 
   const handleTimeUp = useCallback(() => {
     setGameState("ended");
@@ -256,6 +329,31 @@ export default function App() {
     setTimerEnabled(enabled);
     setTimerEndsAt(enabled ? Date.now() + seconds * 1000 : null);
   }, []);
+
+  const requestBroadcastLocation = useCallback(
+    () =>
+      new Promise<{ lat: number; lng: number } | null>((resolve) => {
+        if (typeof navigator === "undefined" || !navigator.geolocation) {
+          resolve(null);
+          return;
+        }
+        navigator.geolocation.getCurrentPosition(
+          (position) => {
+            resolve({
+              lat: position.coords.latitude,
+              lng: position.coords.longitude,
+            });
+          },
+          () => resolve(null),
+          {
+            enableHighAccuracy: false,
+            maximumAge: 5_000,
+            timeout: 8_000,
+          },
+        );
+      }),
+    [],
+  );
 
   const buildGameSnapshot = useCallback(
     (): GameSnapshot => ({
@@ -502,6 +600,7 @@ export default function App() {
     setLockSecretShelter(false);
     setLockShelterOptions(false);
     setRemoteOutcome(null);
+    setMultiplayerPlayerLocations({});
   };
 
   const disconnectSession = useCallback(
@@ -528,6 +627,7 @@ export default function App() {
       setSessionContext(null);
       setCurrentShelter(null);
       setSessionHostId(null);
+      setMultiplayerPlayerLocations({});
     },
     [sessionContext],
   );
@@ -556,6 +656,7 @@ export default function App() {
       setHostShareCode(null);
       setHostSetupModalOpen(false);
       setJoinNameModalOpen(false);
+      setMultiplayerPlayerLocations({});
 
       if (!options?.skipToast) {
         toast.info(
@@ -736,6 +837,7 @@ export default function App() {
     if (!currentShelter) {
       return;
     }
+    setMultiplayerPlayerLocations({});
     setResumeId(crypto.randomUUID());
 
     const label =
@@ -840,6 +942,7 @@ export default function App() {
   const handleSessionEvent = useCallback(
     (message: any) => {
       if (!sessionContext) return;
+      const payload = (message as any)?.payload ?? {};
       switch (message.type) {
         case "player_joined":
         case "ready_updated":
@@ -847,11 +950,59 @@ export default function App() {
           break;
         case "player_left":
         case "player_disconnected":
+          if (payload?.user_id) {
+            setMultiplayerPlayerLocations((previous) => {
+              const next = { ...previous };
+              delete next[String(payload.user_id)];
+              return next;
+            });
+          }
           refreshSessionPlayers(sessionContext.sessionId, sessionContext.token, {
             announceDeparture: true,
-            departedUserId: message.player_id ?? message.user_id,
+            departedUserId: payload.player_id ?? payload.user_id,
           });
           break;
+        case "player_location_removed":
+          if (payload?.user_id) {
+            setMultiplayerPlayerLocations((previous) => {
+              const next = { ...previous };
+              delete next[String(payload.user_id)];
+              return next;
+            });
+          }
+          break;
+        case "player_locations_snapshot": {
+          const locations = Array.isArray(payload?.locations) ? payload.locations : [];
+          setMultiplayerPlayerLocations(() => {
+            const next: Record<string, MultiplayerPlayerLocation> = {};
+            locations.forEach((entry) => {
+              const userId = typeof entry?.user_id === "string" ? entry.user_id : null;
+              const lat = typeof entry?.lat === "number" ? entry.lat : NaN;
+              const lng = typeof entry?.lng === "number" ? entry.lng : NaN;
+              const updatedAt =
+                typeof entry?.updated_at === "number" ? entry.updated_at : Date.now();
+              if (!userId || !Number.isFinite(lat) || !Number.isFinite(lng)) return;
+              next[userId] = { userId, lat, lng, updatedAt };
+            });
+            return next;
+          });
+          break;
+        }
+        case "player_location_updated": {
+          const userId = typeof payload?.user_id === "string" ? payload.user_id : null;
+          const lat = typeof payload?.lat === "number" ? payload.lat : NaN;
+          const lng = typeof payload?.lng === "number" ? payload.lng : NaN;
+          const updatedAt =
+            typeof payload?.updated_at === "number" ? payload.updated_at : Date.now();
+          if (!userId || !Number.isFinite(lat) || !Number.isFinite(lng)) {
+            break;
+          }
+          setMultiplayerPlayerLocations((previous) => ({
+            ...previous,
+            [userId]: { userId, lat, lng, updatedAt },
+          }));
+          break;
+        }
         case "session_closed":
           toast.error(
             t("app.toasts.hostLeft", {
@@ -867,7 +1018,6 @@ export default function App() {
           beginMultiplayerRace();
           break;
         case "race_finished": {
-          const payload = (message as any)?.payload ?? {};
           const winner = payload.winner ?? {};
           console.log("[Multiplayer] race_finished event", payload);
           const winnerName =
@@ -929,6 +1079,70 @@ export default function App() {
       socket.close();
     };
   }, [handleSessionEvent, sessionContext, socketReconnectKey]);
+
+  useEffect(() => {
+    if (!sessionContext || gameState !== "playing") {
+      return undefined;
+    }
+
+    const sendLocationUpdate = async () => {
+      if (locationBroadcastInFlightRef.current) {
+        return;
+      }
+      const socket = sessionSocketRef.current;
+      if (!socket || socket.readyState !== WebSocket.OPEN) {
+        return;
+      }
+
+      locationBroadcastInFlightRef.current = true;
+      try {
+        let location = latestPlayerLocationRef.current;
+        if (!Number.isFinite(location.lat) || !Number.isFinite(location.lng)) {
+          return;
+        }
+
+        const freshLocation = await requestBroadcastLocation();
+        if (
+          freshLocation &&
+          Number.isFinite(freshLocation.lat) &&
+          Number.isFinite(freshLocation.lng)
+        ) {
+          const previousLocation = latestPlayerLocationRef.current;
+          location = freshLocation;
+          latestPlayerLocationRef.current = freshLocation;
+          if (
+            Math.abs(previousLocation.lat - freshLocation.lat) > 1e-6 ||
+            Math.abs(previousLocation.lng - freshLocation.lng) > 1e-6
+          ) {
+            setPlayerLocation(freshLocation);
+          }
+        }
+
+        if (isDefaultStartLocation(location)) {
+          return;
+        }
+
+        const rounded = roundLocationToGrid(location);
+        socket.send(
+          JSON.stringify({
+            type: "location_update",
+            payload: {
+              lat: rounded.lat,
+              lng: rounded.lng,
+            },
+          }),
+        );
+      } finally {
+        locationBroadcastInFlightRef.current = false;
+      }
+    };
+
+    void sendLocationUpdate();
+    const interval = setInterval(() => {
+      void sendLocationUpdate();
+    }, MULTIPLAYER_LOCATION_UPDATE_MS);
+    return () => clearInterval(interval);
+  }, [gameState, requestBroadcastLocation, sessionContext]);
 
   useEffect(() => {
     if (!sessionContext) {
@@ -1549,6 +1763,7 @@ export default function App() {
             gameMode={gameMode}
             lightningCenter={lightningCenter}
             lightningRadiusKm={lightningRadiusKm ?? undefined}
+            otherPlayerLocations={otherPlayerLocations}
             resumeId={resumeId}
             onShowHelp={() => setShowHelp(true)}
           />

--- a/webapp/src/components/GameScreen.tsx
+++ b/webapp/src/components/GameScreen.tsx
@@ -75,6 +75,13 @@ interface GameScreenProps {
   gameMode?: "lightning" | "citywide" | null;
   lightningCenter?: { lat: number; lng: number } | null;
   lightningRadiusKm?: number;
+  otherPlayerLocations?: {
+    userId: string;
+    name: string;
+    lat: number;
+    lng: number;
+    isStale: boolean;
+  }[];
   resumeId?: string;
   onShowHelp?: () => void;
 }
@@ -101,6 +108,7 @@ export function GameScreen({
   gameMode = null,
   lightningCenter = null,
   lightningRadiusKm,
+  otherPlayerLocations = [],
   resumeId,
   onShowHelp,
 }: GameScreenProps) {
@@ -1324,6 +1332,7 @@ export function GameScreen({
         gameMode={gameMode}
         lightningCenter={lightningCenter}
         lightningRadiusKm={lightningRadiusKm ?? LIGHTNING_RADIUS_KM}
+        otherPlayerLocations={otherPlayerLocations}
         onAmenitiesWithinRadius={(info) => {
           setNearbyAmenityCounts(info.counts ?? {});
           setNearbyAmenityCategories(info.matchedCategories ?? []);

--- a/webapp/src/components/MapView.tsx
+++ b/webapp/src/components/MapView.tsx
@@ -263,6 +263,13 @@ interface MapViewProps {
   gameMode?: "lightning" | "citywide" | null;
   lightningCenter?: { lat: number; lng: number } | null;
   lightningRadiusKm?: number;
+  otherPlayerLocations?: {
+    userId: string;
+    name: string;
+    lat: number;
+    lng: number;
+    isStale: boolean;
+  }[];
   onAmenitiesWithinRadius?: (info: { counts: Record<string, number>; matchedCategories: string[] }) => void;
   amenityQueryTrigger?: number;
 }
@@ -294,6 +301,7 @@ export function MapView({
   gameMode,
   lightningCenter,
   lightningRadiusKm = 2,
+  otherPlayerLocations = [],
   onAmenitiesWithinRadius,
   amenityQueryTrigger,
 }: MapViewProps) {
@@ -306,6 +314,7 @@ export function MapView({
   const playerMarker = useRef<mapboxgl.Marker | null>(null);
   const geolocateControl = useRef<mapboxgl.GeolocateControl | null>(null);
 const infoPopup = useRef<mapboxgl.Popup | null>(null);
+const otherPlayerMarkersRef = useRef<Record<string, mapboxgl.Marker>>({});
 const hasSelectedShelter = useRef(false);
 const hasEmittedShelterOptions = useRef(false);
 const pendingPoiRefreshRef = useRef<POI[] | null>(null);
@@ -332,6 +341,62 @@ const measureMarkerRef = useRef<mapboxgl.Marker | null>(null);
   const amenitiesCallbackRef = useRef<
     ((info: { counts: Record<string, number>; matchedCategories: string[] }) => void) | undefined
   >(onAmenitiesWithinRadius);
+
+  const createOtherPlayerMarkerElement = useCallback(
+    (player: { name: string; isStale: boolean }) => {
+      const wrapper = document.createElement("div");
+      wrapper.style.display = "flex";
+      wrapper.style.flexDirection = "column";
+      wrapper.style.alignItems = "center";
+      wrapper.style.pointerEvents = "none";
+      wrapper.style.opacity = player.isStale ? "0.6" : "1";
+
+      const label = document.createElement("div");
+      label.setAttribute("data-role", "label");
+      label.textContent = player.name;
+      label.style.fontSize = "11px";
+      label.style.fontWeight = "700";
+      label.style.padding = "2px 6px";
+      label.style.marginBottom = "4px";
+      label.style.border = "1px solid #000";
+      label.style.borderRadius = "999px";
+      label.style.background = player.isStale ? "#e5e7eb" : "#ffffff";
+      label.style.color = "#000";
+      label.style.whiteSpace = "nowrap";
+      label.style.maxWidth = "140px";
+      label.style.overflow = "hidden";
+      label.style.textOverflow = "ellipsis";
+
+      const dot = document.createElement("div");
+      dot.setAttribute("data-role", "dot");
+      dot.style.width = "14px";
+      dot.style.height = "14px";
+      dot.style.borderRadius = "999px";
+      dot.style.border = "2px solid #000";
+      dot.style.background = player.isStale ? "#9ca3af" : "#ef4444";
+
+      wrapper.appendChild(label);
+      wrapper.appendChild(dot);
+      return wrapper;
+    },
+    [],
+  );
+
+  const updateOtherPlayerMarkerElement = useCallback(
+    (element: HTMLElement, player: { name: string; isStale: boolean }) => {
+      const label = element.querySelector<HTMLElement>("[data-role='label']");
+      const dot = element.querySelector<HTMLElement>("[data-role='dot']");
+      element.style.opacity = player.isStale ? "0.6" : "1";
+      if (label) {
+        label.textContent = player.name;
+        label.style.background = player.isStale ? "#e5e7eb" : "#ffffff";
+      }
+      if (dot) {
+        dot.style.background = player.isStale ? "#9ca3af" : "#ef4444";
+      }
+    },
+    [],
+  );
 
   // Koto layer visibility state
   const [kotoLayersVisible, setKotoLayersVisible] = useState<
@@ -1437,6 +1502,8 @@ const measureMarkerRef = useRef<mapboxgl.Marker | null>(null);
           map.current.off("idle", pendingPoiRefreshHandlerRef.current);
           pendingPoiRefreshHandlerRef.current = null;
         }
+        Object.values(otherPlayerMarkersRef.current).forEach((marker) => marker.remove());
+        otherPlayerMarkersRef.current = {};
         map.current?.off("styledata", moveAttributionToBottomLeft);
         map.current.remove();
         map.current = null;
@@ -1468,6 +1535,44 @@ const measureMarkerRef = useRef<mapboxgl.Marker | null>(null);
       setHasUserLocationFix(true);
     }
   }, [playerLocation.lng, playerLocation.lat, hasUserLocationFix]);
+
+  useEffect(() => {
+    const m = map.current;
+    if (!m) return;
+
+    const nextIds = new Set(otherPlayerLocations.map((player) => player.userId));
+
+    Object.entries(otherPlayerMarkersRef.current).forEach(([userId, marker]) => {
+      if (nextIds.has(userId)) return;
+      marker.remove();
+      delete otherPlayerMarkersRef.current[userId];
+    });
+
+    otherPlayerLocations.forEach((player) => {
+      if (!Number.isFinite(player.lat) || !Number.isFinite(player.lng)) {
+        return;
+      }
+
+      const existingMarker = otherPlayerMarkersRef.current[player.userId];
+      if (existingMarker) {
+        existingMarker.setLngLat([player.lng, player.lat]);
+        updateOtherPlayerMarkerElement(existingMarker.getElement(), player);
+        return;
+      }
+
+      const markerElement = createOtherPlayerMarkerElement(player);
+      otherPlayerMarkersRef.current[player.userId] = new mapboxgl.Marker({
+        element: markerElement,
+        anchor: "bottom",
+      })
+        .setLngLat([player.lng, player.lat])
+        .addTo(m);
+    });
+  }, [
+    createOtherPlayerMarkerElement,
+    otherPlayerLocations,
+    updateOtherPlayerMarkerElement,
+  ]);
 
   useEffect(() => {
     const m = map.current;


### PR DESCRIPTION
## Summary
- fix multiplayer location broadcast to refresh geolocation on each 5s tick before sending
- keep server-side 50m coordinate rounding and 1 minute stale handling
- document heartbeat behavior (204 No Content) and location-update behavior in root/API READMEs

## Validation
- npm --prefix webapp run build
- npm --prefix api run check